### PR TITLE
feat: add loading dialog to simulation

### DIFF
--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -33,6 +33,8 @@ export class BankApplicationService {
     let gas: proto.cosmos.base.v1beta1.ICoin;
     let fee: proto.cosmos.base.v1beta1.ICoin;
 
+    const dialogRefSimulating = this.loadingDialog.open('Simulating...');
+
     try {
       simulatedResultData = await this.bank.simulateToSend(
         key,
@@ -48,6 +50,8 @@ export class BankApplicationService {
       const errorMessage = `Tx simulation failed: ${(error as Error).toString()}`;
       this.snackBar.open(`An error has occur: ${errorMessage}`);
       return;
+    } finally {
+      dialogRefSimulating.close();
     }
 
     // ask the user to confirm the fee with a dialog

--- a/projects/main/src/app/models/cosmos/staking.application.service.ts
+++ b/projects/main/src/app/models/cosmos/staking.application.service.ts
@@ -39,6 +39,8 @@ export class StakingApplicationService {
     let gas: proto.cosmos.base.v1beta1.ICoin;
     let fee: proto.cosmos.base.v1beta1.ICoin;
 
+    const dialogRefSimulating = this.loadingDialog.open('Simulating...');
+
     try {
       simulatedResultData = await this.staking.simulateToCreateValidator(
         key,
@@ -52,6 +54,8 @@ export class StakingApplicationService {
       const errorMessage = `Tx simulation failed: ${(error as Error).toString()}`;
       this.snackBar.open(`An error has occur: ${errorMessage}`);
       return;
+    } finally {
+      dialogRefSimulating.close();
     }
 
     // ask the user to confirm the fee with a dialog


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

REST APIにアクセス集中していないときはsimulateのAPIレスポンスは比較的すぐ返ってくるのでこれまであまり気にならなかったのですが、REST APIにアクセス集中しているときはsimulateのAPIのレスポンスもそれなりに待ち時間が発生するようで、simulateのAPIのレスポンスの待ち時間の際loading dialogを表示していなかったので、ボタンを押せていないと勘違いして何度もトランザクション送信ボタンを押してしまうパターンの問題があったようで、その対策の修正です。UnUniFi/utilsの方も同様に修正しておこうと思います。