### PR TITLE
feat: add cd push docker image for private testnet

### DIFF
--- a/.github/workflows/docker-monitor-private-test.yml
+++ b/.github/workflows/docker-monitor-private-test.yml
@@ -1,0 +1,29 @@
+name: Publish Monitor Docker image for Private Testnet
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  push_to_registry:
+    name: Push Docker image for Private Testnet to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup variables
+        id: variables
+        run: echo "::set-output name=version::${GITHUB_REF##*/}"
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: ./projects/monitor
+          file: ./projects/monitor/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/cauchye/telescope-monitor:test

--- a/.github/workflows/docker-telescope-private-test.yml
+++ b/.github/workflows/docker-telescope-private-test.yml
@@ -1,0 +1,37 @@
+name: Publish Telescope Docker image for Private Testnet
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  push_to_registry:
+    name: Push Docker image for Private Testnet to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup variables
+        id: variables
+        run: echo "::set-output name=version::${GITHUB_REF##*/}"
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./projects/main/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/cauchye/telescope:test
+      - name: Create GitHub dispatch event
+        run: |
+          curl --request POST 'https://api.github.com/repos/UnUniFi/utils/dispatches' \
+          --header 'Authorization: Bearer ${{secrets.REPO_GITHUB_ACCESS_TOKEN}}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+            "event_type": "repository-telescope-new-release-for-private-testnet"
+          }'


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

developにマージされた際、Private Testnet用のDockerイメージがタグ: testで公開されるよう、GitHub Actionsを追加しました。
telescopeについては、そのあと、UnUniFi/utils レポジトリに対して(リリース時とは別の)dispatchイベントを発火させるよう修正を加えています。