### PR TITLE
feat: remove unintentional whitespace in private key

### DIFF
--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -33,9 +33,6 @@ export class BankApplicationService {
     let gas: proto.cosmos.base.v1beta1.ICoin;
     let fee: proto.cosmos.base.v1beta1.ICoin;
 
-    // remove unintentional whitespace
-    const privateKeyWithNoWhitespace = privateKey.replace(/\s+/g, '');
-
     const dialogRefSimulating = this.loadingDialog.open('Simulating...');
 
     try {
@@ -44,7 +41,7 @@ export class BankApplicationService {
         toAddress,
         amount,
         minimumGasPrice,
-        privateKeyWithNoWhitespace,
+        privateKey,
       );
       gas = simulatedResultData.estimatedGasUsedWithMargin;
       fee = simulatedResultData.estimatedFeeWithMargin;
@@ -78,14 +75,7 @@ export class BankApplicationService {
     let txhash: string | undefined;
 
     try {
-      const res = await this.bank.send(
-        key,
-        toAddress,
-        amount,
-        gas,
-        fee,
-        privateKeyWithNoWhitespace,
-      );
+      const res = await this.bank.send(key, toAddress, amount, gas, fee, privateKey);
       txhash = res.tx_response?.txhash;
       if (txhash === undefined) {
         throw Error('Invalid txhash!');

--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -33,6 +33,9 @@ export class BankApplicationService {
     let gas: proto.cosmos.base.v1beta1.ICoin;
     let fee: proto.cosmos.base.v1beta1.ICoin;
 
+    // remove unintentional whitespace
+    const privateKeyWithNoWhitespace = privateKey.replace(/\s+/g, '');
+
     const dialogRefSimulating = this.loadingDialog.open('Simulating...');
 
     try {
@@ -41,7 +44,7 @@ export class BankApplicationService {
         toAddress,
         amount,
         minimumGasPrice,
-        privateKey,
+        privateKeyWithNoWhitespace,
       );
       gas = simulatedResultData.estimatedGasUsedWithMargin;
       fee = simulatedResultData.estimatedFeeWithMargin;
@@ -75,7 +78,14 @@ export class BankApplicationService {
     let txhash: string | undefined;
 
     try {
-      const res = await this.bank.send(key, toAddress, amount, gas, fee, privateKey);
+      const res = await this.bank.send(
+        key,
+        toAddress,
+        amount,
+        gas,
+        fee,
+        privateKeyWithNoWhitespace,
+      );
       txhash = res.tx_response?.txhash;
       if (txhash === undefined) {
         throw Error('Invalid txhash!');

--- a/projects/main/src/app/models/cosmos/bank.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.service.ts
@@ -64,7 +64,8 @@ export class BankService {
     privateKey: string,
   ): Promise<cosmosclient.TxBuilder> {
     const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
-    const privKey = this.key.getPrivKey(key.type, privateKey);
+    const privateKeyWithNoWhitespace = privateKey.replace(/\s+/g, '');
+    const privKey = this.key.getPrivKey(key.type, privateKeyWithNoWhitespace);
     const pubKey = privKey.pubKey();
     const fromAddress = cosmosclient.AccAddress.fromPublicKey(pubKey);
 


### PR DESCRIPTION
[https://github.com/CauchyE/telescope/issues/248](https://github.com/CauchyE/telescope/issues/248)の修正です。

bank/send で秘密鍵を入力する際に、空白文字を切るように、以下と同様に修正しました。
[https://github.com/CauchyE/telescope/pull/247](https://github.com/CauchyE/telescope/pull/247)

ローカルで秘密鍵の前後にスペースを付加して動作確認しました。ご確認お願い致します。