### PR TITLE
Hotfix/pagination query

### DIFF
--- a/projects/main/src/app/pages/blocks/blocks.component.html
+++ b/projects/main/src/app/pages/blocks/blocks.component.html
@@ -1,5 +1,5 @@
 <view-blocks
-  [latestBlocks]="latestBlocks$ | async"
+  [blocks]="blocks$ | async"
   [pageSize]="pageSize$ | async"
   [pageNumber]="pageNumber$ | async"
   [pageLength]="pageLength$ | async"

--- a/projects/main/src/app/pages/blocks/blocks.component.ts
+++ b/projects/main/src/app/pages/blocks/blocks.component.ts
@@ -34,6 +34,7 @@ export class BlocksComponent implements OnInit {
     this.latestBlock$ = sdk$.pipe(
       mergeMap((sdk) => rest.tendermint.getLatestBlock(sdk.rest).then((res) => res.data)),
     );
+
     this.latestBlock$.subscribe((latestBlock) => {
       this.latestBlockHeight$.next(
         latestBlock?.block?.header?.height ? BigInt(latestBlock.block.header.height) : BigInt(0),
@@ -47,15 +48,22 @@ export class BlocksComponent implements OnInit {
       this.pageNumber$.next(0);
     });
 
+    //add
     this.route.queryParams.subscribe((params) => {
       console.log('pages', params); // { order: "popular" }
 
-      this.pageSize$.next(params.perPage);
+      console.log(this.pageSizeOptions.includes(Number(params.perPage)));
+      if (this.pageSizeOptions.includes(Number(params.perPage))) {
+        console.log('inclide', params.perPage);
+        this.pageSize$.next(params.perPage);
+      }
       this.pageNumber$.next(params.pages);
       console.log(this.pageSize$.getValue(), this.pageNumber$.getValue());
 
       const paginatedBlockHeight =
-        this.latestBlockHeight$.getValue() - BigInt(params.pages - 1) * BigInt(params.perPage);
+        this.latestBlockHeight$.getValue() - BigInt(params.pages - 1) * BigInt(params.perPage) > 0
+          ? this.latestBlockHeight$.getValue() - BigInt(params.pages - 1) * BigInt(params.perPage)
+          : BigInt(100);
       console.log('paginatedBlockHeight', paginatedBlockHeight);
 
       this.firstBlockHeight$.next(paginatedBlockHeight);
@@ -64,6 +72,7 @@ export class BlocksComponent implements OnInit {
     this.latestBlocks$ = combineLatest([this.firstBlockHeight$, this.pageSize$]).pipe(
       map(([firstBlockHeight, pageSize]) =>
         [...Array(pageSize).keys()].map((index) => {
+          console.log('index', index);
           const tempLatestBlockHeight =
             firstBlockHeight === undefined ? BigInt(0) : firstBlockHeight;
           return tempLatestBlockHeight - BigInt(index);
@@ -85,13 +94,24 @@ export class BlocksComponent implements OnInit {
         return of(undefined);
       }),
     );
+
+    this.pageSize$.subscribe((x) => console.log('pageSize', x));
+    this.firstBlockHeight$.subscribe((x) => console.log('1stBlockH', x));
   }
 
   ngOnInit(): void {}
 
   appPaginationChanged(pageEvent: PageEvent): void {
+    /*
+    this.pageSize$.next(pageEvent.pageSize);
+    this.pageNumber$.next(pageEvent.pageIndex + 1);
     this.pageLength$.next(pageEvent.length);
+    const paginatedBlockHeight =
+      this.latestBlockHeight$.getValue() - BigInt(pageEvent.pageIndex) * BigInt(pageEvent.pageSize);
+    this.firstBlockHeight$.next(paginatedBlockHeight);
+    */
 
+    //add
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: {

--- a/projects/main/src/app/pages/blocks/blocks.component.ts
+++ b/projects/main/src/app/pages/blocks/blocks.component.ts
@@ -23,6 +23,7 @@ export class BlocksComponent implements OnInit {
   latestBlockHeight$: Observable<bigint>;
   latestBlocks$: Observable<InlineResponse20036[] | undefined>;
   firstBlockHeight$: Observable<bigint>;
+
   constructor(
     private router: Router,
     private route: ActivatedRoute,
@@ -46,7 +47,15 @@ export class BlocksComponent implements OnInit {
       ),
     );
 
-    this.pageNumber$ = this.route.queryParams.pipe(map((params) => Number(params.pages)));
+    this.pageNumber$ = this.route.queryParams.pipe(
+      map((params) => {
+        if (Number(params.pages)) {
+          return Number(params.pages);
+        } else {
+          return 1;
+        }
+      }),
+    );
 
     this.pageSize$ = this.route.queryParams.pipe(
       map((params) => {
@@ -76,7 +85,6 @@ export class BlocksComponent implements OnInit {
     this.latestBlocks$ = combineLatest([this.firstBlockHeight$, this.pageSize$]).pipe(
       map(([firstBlockHeight, pageSize]) =>
         [...Array(pageSize).keys()].map((index) => {
-          //console.log('index', index);
           const tempLatestBlockHeight =
             firstBlockHeight === undefined ? BigInt(0) : firstBlockHeight;
           return tempLatestBlockHeight - BigInt(index);

--- a/projects/main/src/app/pages/blocks/blocks.component.ts
+++ b/projects/main/src/app/pages/blocks/blocks.component.ts
@@ -65,8 +65,8 @@ export class BlocksComponent implements OnInit {
     ]).pipe(
       map(([pageLength, pageSize, params]) => {
         const pages = Number(params.pages);
-        if (!pages) return 2;
-        if (pages > pageLength / pageSize + 1) return 3;
+        if (!pages) return 1;
+        if (pages > pageLength / pageSize + 1) return 1;
         return pages;
       }),
     );

--- a/projects/main/src/app/pages/blocks/blocks.component.ts
+++ b/projects/main/src/app/pages/blocks/blocks.component.ts
@@ -51,8 +51,8 @@ export class BlocksComponent implements OnInit {
     //add
     this.route.queryParams.subscribe((params) => {
       console.log('pages', params); // { order: "popular" }
-
       console.log(this.pageSizeOptions.includes(Number(params.perPage)));
+
       if (this.pageSizeOptions.includes(Number(params.perPage))) {
         console.log('inclide', params.perPage);
         this.pageSize$.next(params.perPage);
@@ -71,7 +71,7 @@ export class BlocksComponent implements OnInit {
 
     this.latestBlocks$ = combineLatest([this.firstBlockHeight$, this.pageSize$]).pipe(
       map(([firstBlockHeight, pageSize]) =>
-        [...Array(pageSize).keys()].map((index) => {
+        [...Array(pageSize * 1).keys()].map((index) => {
           console.log('index', index);
           const tempLatestBlockHeight =
             firstBlockHeight === undefined ? BigInt(0) : firstBlockHeight;

--- a/projects/main/src/app/pages/blocks/blocks.component.ts
+++ b/projects/main/src/app/pages/blocks/blocks.component.ts
@@ -17,7 +17,7 @@ export class BlocksComponent implements OnInit {
   pageSize$: Observable<number>;
   pageNumber$: Observable<number>;
   pageLength$: Observable<number | undefined>;
-  defaultPageSize = 10;
+  defaultPageSize = this.pageSizeOptions[1];
   defaultPageNumber = 1;
 
   pollingInterval = 30;

--- a/projects/main/src/app/views/app.component.html
+++ b/projects/main/src/app/views/app.component.html
@@ -16,7 +16,7 @@
       <mat-list-item routerLink="/">
         <mat-icon class="mr-2" color="primary">other_houses</mat-icon>Home
       </mat-list-item>
-      <mat-list-item routerLink="/blocks" [queryParams]="{ perPage: '10', pages: '1' }">
+      <mat-list-item routerLink="/blocks">
         <mat-icon class="mr-2" color="primary">account_tree</mat-icon>Blocks
       </mat-list-item>
       <mat-list-item routerLink="/txs">

--- a/projects/main/src/app/views/app.component.html
+++ b/projects/main/src/app/views/app.component.html
@@ -16,7 +16,7 @@
       <mat-list-item routerLink="/">
         <mat-icon class="mr-2" color="primary">other_houses</mat-icon>Home
       </mat-list-item>
-      <mat-list-item routerLink="/blocks">
+      <mat-list-item routerLink="/blocks" [queryParams]="{ perPage: '10', pages: '1' }">
         <mat-icon class="mr-2" color="primary">account_tree</mat-icon>Blocks
       </mat-list-item>
       <mat-list-item routerLink="/txs">

--- a/projects/main/src/app/views/blocks/blocks.component.html
+++ b/projects/main/src/app/views/blocks/blocks.component.html
@@ -1,7 +1,7 @@
 <h2>Blocks</h2>
 <div>
   <mat-card>
-    <ng-container *ngIf="latestBlocks === undefined || null; then empty; else exist"></ng-container>
+    <ng-container *ngIf="blocks === undefined || null; then empty; else exist"></ng-container>
     <ng-template #empty></ng-template>
     <ng-template #exist>
       <mat-list>
@@ -12,13 +12,13 @@
         </mat-list-item>
       </mat-list>
       <mat-nav-list>
-        <ng-container *ngFor="let latestBlock of latestBlocks">
+        <ng-container *ngFor="let block of blocks">
           <mat-divider></mat-divider>
-          <mat-list-item routerLink="/blocks/{{ latestBlock?.block?.header?.height }}">
-            <span class="pr-4">{{ latestBlock?.block?.header?.height }}</span>
+          <mat-list-item routerLink="/blocks/{{ block?.block?.header?.height }}">
+            <span class="pr-4">{{ block?.block?.header?.height }}</span>
             <span class="flex-auto"></span>
             <span class="break-all text-sm sm:text-base">
-              {{ latestBlock?.block?.header?.time | date : 'yyyy-M-d a h:mm:ss z' }}
+              {{ block?.block?.header?.time | date : 'yyyy-M-d a h:mm:ss z' }}
             </span>
           </mat-list-item>
           <mat-divider></mat-divider>

--- a/projects/main/src/app/views/blocks/blocks.component.ts
+++ b/projects/main/src/app/views/blocks/blocks.component.ts
@@ -9,7 +9,7 @@ import { InlineResponse20035 } from '@cosmos-client/core/esm/openapi';
 })
 export class BlocksComponent implements OnInit {
   @Input()
-  latestBlocks?: InlineResponse20035[] | null;
+  blocks?: InlineResponse20035[] | null;
 
   @Input()
   pageSizeOptions?: number[] | null;


### PR DESCRIPTION
引き続き動作確認はできていないのですが、確認のためPR作成します。

・paginationの変更で発火するイベント内でrouter.navigate()関数を使って、URLにページネーションの情報をマージ。
・`this.route.queryParams`でクエリパラメータの変化を購読して、コンポーネント内で使用しているBehaiverSubjectを更新。

方針としては外れていないと思っているのですが、後述するようにページサイズに関わらず１つの情報しか表示されない状況です。

![image](https://user-images.githubusercontent.com/75844498/149337835-14fbdafd-e882-42ed-a58d-b86fc45637c5.png)
