### PR TITLE
fix: add (chain_id) to Network in home page

### DIFF
--- a/projects/main/src/app/views/home/home.component.html
+++ b/projects/main/src/app/views/home/home.component.html
@@ -3,7 +3,7 @@
   <mat-card-content>
     <mat-list>
       <mat-list-item>
-        <span class="whitespace-nowrap">Network: </span>
+        <span class="whitespace-nowrap">Network (chain_id): </span>
         <span class="flex-auto"></span>
         <span class="ml-2 break-all">{{ nodeInfo?.default_node_info?.network }}</span>
       </mat-list-item>


### PR DESCRIPTION
[https://github.com/CauchyE/telescope/issues/246](https://github.com/CauchyE/telescope/issues/246)の修正です。
以下の通り表示追加しました。

![20220117_pic](https://user-images.githubusercontent.com/75844498/149767513-6ff50fff-4661-4d1c-a67c-957bfa0faef5.png)

ご確認お願い致します。