### PR TITLE
fix: remove whitespace in keyservice

### DIFF
--- a/projects/main/src/app/models/cosmos/bank.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.service.ts
@@ -64,8 +64,7 @@ export class BankService {
     privateKey: string,
   ): Promise<cosmosclient.TxBuilder> {
     const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
-    const privateKeyWithNoWhitespace = privateKey.replace(/\s+/g, '');
-    const privKey = this.key.getPrivKey(key.type, privateKeyWithNoWhitespace);
+    const privKey = this.key.getPrivKey(key.type, privateKey);
     const pubKey = privKey.pubKey();
     const fromAddress = cosmosclient.AccAddress.fromPublicKey(pubKey);
 

--- a/projects/main/src/app/models/keys/key.service.ts
+++ b/projects/main/src/app/models/keys/key.service.ts
@@ -24,19 +24,23 @@ export class KeyService {
   }
 
   getPrivKey(type: KeyType, privateKey: string) {
-    return this.iKeyInfrastructure.getPrivKey(type, privateKey);
+    const privateKeyWithNoWhitespace = privateKey.replace(/\s+/g, '');
+    return this.iKeyInfrastructure.getPrivKey(type, privateKeyWithNoWhitespace);
   }
 
   getPubKey(type: KeyType, publicKey: string) {
-    return this.iKeyInfrastructure.getPubKey(type, publicKey);
+    const publicKeyWithNoWhitespace = publicKey.replace(/\s+/g, '');
+    return this.iKeyInfrastructure.getPubKey(type, publicKeyWithNoWhitespace);
   }
 
   sign(type: KeyType, privateKey: string, message: Uint8Array) {
-    return this.iKeyInfrastructure.sign(type, privateKey, message);
+    const privateKeyWithNoWhitespace = privateKey.replace(/\s+/g, '');
+    return this.iKeyInfrastructure.sign(type, privateKeyWithNoWhitespace, message);
   }
 
   getPrivateKeyFromMnemonic(mnemonic: string) {
-    return this.iKeyInfrastructure.getPrivateKeyFromMnemonic(mnemonic);
+    const mnemonicWithNoWhitespace = mnemonic.trim();
+    return this.iKeyInfrastructure.getPrivateKeyFromMnemonic(mnemonicWithNoWhitespace);
   }
 
   get(id: string) {

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -27,7 +27,7 @@ export class CreateComponent implements OnInit {
     this.privateKey = '';
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   onClickCreateMnemonic() {
     this.mnemonic = bip39.generateMnemonic();
@@ -53,8 +53,9 @@ and store them safely and confidentially without disclosing them to others.\
   }
 
   async onSubmit($event: CreateOnSubmitEvent) {
+    const mnemonicWithNoWhitespace = $event.mnemonic.trim();
     this.keyBackupResult = await this.keyBackupDialog.open(
-      $event.mnemonic,
+      mnemonicWithNoWhitespace,
       $event.privateKey,
       $event.id,
     );


### PR DESCRIPTION
[https://github.com/UnUniFi/utils/pull/190](https://github.com/UnUniFi/utils/pull/190)の逆輸入です。

＜変更点＞
・秘密鍵から空白文字を除く実装をbankServiceからkeyServiceに移動。
・同時に公開鍵の空白文字削除と、ニーモニックの前後の空白文字削除。

＜デバック＞
修正箇所はkeyServiceの以下４つのメソッドで、
以下の通り動作に問題ないことを確認しました。

getPrivkey⇒
bank/sendで空白文字を入れた秘密鍵で送信できることを確認。

getPubkey⇒
ユーザー入力で使用する箇所なし。

sign⇒
keys/signで空白文字を入れた秘密鍵を入力し、空白文字に関係なく、signature(Base64)の表示が変わらないことを確認。
![20220119_pic](https://user-images.githubusercontent.com/75844498/150143656-5853a576-b3c0-4d0b-91ec-58d69a24e951.png)

getPrivateKeyFormMnemonic⇒
bank/createで空白文字を入れたニーモニックでアカウントを作成し、confirmダイアログの認証が通ることを確認。
