### PR TITLE
fix: fix object display in tx page

### DIFF
--- a/projects/main/src/app/views/txs/tx/tx.component.html
+++ b/projects/main/src/app/views/txs/tx/tx.component.html
@@ -33,10 +33,9 @@
       <span class="whitespace-nowrap">Timestamp: </span>
       <span class="flex-auto"></span>
       <span class="ml-2 break-all text-xs sm:text-base">
-        {{ tx?.tx_response?.timestamp | date : 'yyyy-M-d a h:mm:ss z' }}
+        {{ tx?.tx_response?.timestamp | date: 'yyyy-M-d a h:mm:ss z' }}
       </span>
     </mat-list-item>
-
   </mat-list>
 </mat-card>
 
@@ -78,13 +77,13 @@
         <mat-list-item>
           <span class="whitespace-nowrap">Public Key: </span>
           <span class="flex-auto"></span>
-          <span class="ml-2 break-all">{{ pubKey?.toString() }}</span>
+          <span class="ml-2 break-all">{{ getPublicKey(pubKey) }}</span>
         </mat-list-item>
         <mat-divider [inset]="true"></mat-divider>
         <mat-list-item>
           <span class="whitespace-nowrap">Signature: </span>
           <span class="flex-auto"></span>
-          <span class="ml-2 break-all">{{ signerInfo?.mode_info }}</span>
+          <span class="ml-2 break-all">{{ signerInfo?.mode_info?.single?.mode }}</span>
         </mat-list-item>
       </mat-list>
     </mat-card>

--- a/projects/main/src/app/views/txs/tx/tx.component.ts
+++ b/projects/main/src/app/views/txs/tx/tx.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { cosmosclient } from '@cosmos-client/core';
+import { cosmosclient, proto } from '@cosmos-client/core';
 import { CosmosTxV1beta1GetTxResponse } from '@cosmos-client/core/esm/openapi';
 
 @Component({
@@ -37,5 +37,12 @@ export class TxComponent implements OnInit {
 
   entries(value: unknown) {
     return Object.entries(value as any);
+  }
+
+  getPublicKey(pubkey: any): string {
+    const publicKey = new proto.cosmos.crypto.secp256k1.PubKey({
+      key: pubkey.key,
+    });
+    return cosmosclient.AccAddress.fromPublicKey(publicKey).toString();
   }
 }


### PR DESCRIPTION
[https://github.com/CauchyE/telescope/issues/220](https://github.com/CauchyE/telescope/issues/220)の（一部）修正です。

/txs/##txHash## の以下の表記を修正しました。
もともとのコードから意図していたものを表示していますが、
微妙に合っていない気もします。（keyTypeは「secp256k1」？）

![image](https://user-images.githubusercontent.com/75844498/151365187-34fe91fa-8dd2-451e-ba83-6988171f9584.png)

ご確認お願いいたします。