### PR TITLE
fix: card title margin

### DIFF
--- a/projects/main/src/app/views/accounts/account/account.component.html
+++ b/projects/main/src/app/views/accounts/account/account.component.html
@@ -1,52 +1,52 @@
-<h2>Account Info</h2>
-<ng-container *ngIf="baseAccount === undefined || null ; then empty; else exist"></ng-container>
+<h2 class="mb-0">Account Info</h2>
+<ng-container *ngIf="baseAccount === undefined || null; then empty; else exist"></ng-container>
 
 <ng-template #empty>
   <span>*This account has no denoms</span>
 </ng-template>
 
 <ng-template #exist>
-  <mat-card *ngIf="baseAccount">
+  <mat-card class="mb-4" *ngIf="baseAccount">
     <mat-list>
       <mat-list-item>
         <span class="whitespace-nowrap">Sequence:</span>
         <span class="flex-auto"></span>
         <span class="ml-2 break-all">{{ baseAccount?.sequence }}</span>
+        <mat-divider [inset]="true"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
 
       <mat-list-item>
         <span class="whitespace-nowrap">Account Number: </span>
         <span class="flex-auto"></span>
         <span class="ml-2 break-all">{{ baseAccount?.account_number }}</span>
+        <mat-divider [inset]="true"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
 
       <mat-list-item>
         <span class="whitespace-nowrap">Address: </span>
         <span class="flex-auto"></span>
         <span class="ml-2 break-all text-sm sm:text-base">{{ baseAccount?.address }}</span>
+        <mat-divider [inset]="true"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
 
       <mat-list-item>
         <span class="whitespace-nowrap">Public key: </span>
         <span class="flex-auto"></span>
         <span class="ml-2 break-all text-xs md:text-base">{{ publicKey }}</span>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 
-  <h2>Coins</h2>
-  <mat-card>
-    <mat-list *ngFor="let balance of balances">
+  <h2 class="mb-0">Coins</h2>
+  <mat-card class="mb-4">
+    <mat-list *ngFor="let balance of balances; last as last">
       <mat-list-item>
-        <span class="whitespace-nowrap">{{ balance.amount | number:'1.0-0' }}</span>
         <span class="flex-auto"></span>
-        <span class="ml-2 break-all">{{ balance.denom }}</span>
+        <span class="mr-2">{{ balance.amount | number: '1.0-0' }}</span>
+        <span>{{ balance.denom }}</span>
+        <span *ngIf="balance?.denom?.length == 3" class="mr-2"></span>
+        <mat-divider *ngIf="!last"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -1,16 +1,22 @@
-<h2>Validator Rewards</h2>
+<h2 class="mb-0">Validator Rewards</h2>
 
-<ng-container *ngIf="(commission?.commission?.commission?.length || 0) > 0; then existCommission; else emptyCommission">
+<ng-container
+  *ngIf="
+    (commission?.commission?.commission?.length || 0) > 0;
+    then existCommission;
+    else emptyCommission
+  "
+>
 </ng-container>
 <ng-template #emptyCommission>
   <p>*This account has no commission</p>
 </ng-template>
 <ng-template #existCommission>
   <h3>Accumulated Commission</h3>
-  <mat-card>
+  <mat-card class="mb-4">
     <mat-list *ngFor="let commission of commission?.commission?.commission">
       <mat-list-item>
-        <span>{{ commission.amount | number:'1.6-6' }}</span>
+        <span>{{ commission.amount | number: '1.6-6' }}</span>
         <span class="flex-auto"></span>
         <span>{{ commission.denom }}</span>
       </mat-list-item>
@@ -19,17 +25,19 @@
   </mat-card>
 </ng-template>
 
-<ng-container *ngIf="(rewards?.rewards?.rewards?.length || 0) > 0; then existRewards; else emptyRewards">
+<ng-container
+  *ngIf="(rewards?.rewards?.rewards?.length || 0) > 0; then existRewards; else emptyRewards"
+>
 </ng-container>
 <ng-template #emptyRewards>
   <p>*This account has no outstanding rewards</p>
 </ng-template>
 <ng-template #existRewards>
   <h3>Outstanding Rewards</h3>
-  <mat-card>
+  <mat-card class="mb-4">
     <mat-list *ngFor="let reward of rewards?.rewards?.rewards">
       <mat-list-item>
-        <span>{{ reward.amount | number:'1.6-6' }}</span>
+        <span>{{ reward.amount | number: '1.6-6' }}</span>
         <span class="flex-auto"></span>
         <span>{{ reward.denom }}</span>
       </mat-list-item>
@@ -45,7 +53,7 @@
 </ng-template>
 <ng-template #existSlashes>
   <h3>Slashing</h3>
-  <mat-card>
+  <mat-card class="mb-4">
     <mat-list *ngFor="let slash of slashes?.slashes">
       <mat-list-item>
         <span>Validator Period:</span>

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -12,15 +12,15 @@
   <p>*This account has no commission</p>
 </ng-template>
 <ng-template #existCommission>
-  <h3>Accumulated Commission</h3>
-  <mat-card class="mb-4">
-    <mat-list *ngFor="let commission of commission?.commission?.commission">
+  <h3 class="ml-4 mb-0">Accumulated Commission</h3>
+  <mat-card class="mb-2">
+    <mat-list *ngFor="let commission of commission?.commission?.commission; last as last">
       <mat-list-item>
-        <span>{{ commission.amount | number: '1.6-6' }}</span>
         <span class="flex-auto"></span>
+        <span class="mr-2">{{ commission.amount | number: '1.6-6' }}</span>
         <span>{{ commission.denom }}</span>
+        <mat-divider *ngIf="!last"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>
@@ -33,15 +33,15 @@
   <p>*This account has no outstanding rewards</p>
 </ng-template>
 <ng-template #existRewards>
-  <h3>Outstanding Rewards</h3>
-  <mat-card class="mb-4">
-    <mat-list *ngFor="let reward of rewards?.rewards?.rewards">
+  <h3 class="ml-4 mb-0">Outstanding Rewards</h3>
+  <mat-card class="mb-2">
+    <mat-list *ngFor="let reward of rewards?.rewards?.rewards; last as last">
       <mat-list-item>
-        <span>{{ reward.amount | number: '1.6-6' }}</span>
         <span class="flex-auto"></span>
+        <span class="mr-2">{{ reward.amount | number: '1.6-6' }}</span>
         <span>{{ reward.denom }}</span>
+        <mat-divider *ngIf="!last"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>
@@ -52,21 +52,20 @@
   <p>*This account has no slashes</p>
 </ng-template>
 <ng-template #existSlashes>
-  <h3>Slashing</h3>
-  <mat-card class="mb-4">
-    <mat-list *ngFor="let slash of slashes?.slashes">
+  <h3 class="ml-4 mb-0">Slashing</h3>
+  <mat-card class="mb-2" *ngFor="let slash of slashes?.slashes">
+    <mat-list>
       <mat-list-item>
         <span>Validator Period:</span>
         <span class="flex-auto"></span>
         <span>{{ slash.validator_period }}</span>
+        <mat-divider></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
       <mat-list-item>
         <span>Fraction:</span>
         <span class="flex-auto"></span>
-        <span>{{ slash.fraction }}</span>
+        <span>{{ slash.fraction | number: '1.6-6' }}</span>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>

--- a/projects/main/src/app/views/accounts/account/staking/staking.component.html
+++ b/projects/main/src/app/views/accounts/account/staking/staking.component.html
@@ -1,16 +1,18 @@
-<h2>Delegator Rewards</h2>
+<h2 class="mb-0">Delegator Rewards</h2>
 
-<ng-container *ngIf="(totalRewards?.total?.length || 0) > 0; then existTotalRewards; else emptyTotalRewards">
+<ng-container
+  *ngIf="(totalRewards?.total?.length || 0) > 0; then existTotalRewards; else emptyTotalRewards"
+>
 </ng-container>
 <ng-template #emptyTotalRewards>
   <p>*This account has no total rewards</p>
 </ng-template>
 <ng-template #existTotalRewards>
   <h3>Total Rewards</h3>
-  <mat-card>
+  <mat-card class="mb-4">
     <mat-list *ngFor="let eachTotalReward of totalRewards?.total">
       <mat-list-item>
-        <span>{{ eachTotalReward.amount | number:'1.6-6' }}</span>
+        <span>{{ eachTotalReward.amount | number: '1.6-6' }}</span>
         <span class="flex-auto"></span>
         <span>{{ eachTotalReward.denom }}</span>
       </mat-list-item>
@@ -20,14 +22,19 @@
 </ng-template>
 
 <ng-container
-  *ngIf="(totalRewards?.rewards?.length || 0) > 0; then existEachValidatorRewards; else emptyEachValidatorRewards">
+  *ngIf="
+    (totalRewards?.rewards?.length || 0) > 0;
+    then existEachValidatorRewards;
+    else emptyEachValidatorRewards
+  "
+>
 </ng-container>
 <ng-template #emptyEachValidatorRewards>
   <p>*This account has not received any rewards from validators</p>
 </ng-template>
 <ng-template #existEachValidatorRewards>
   <h3>Rewards by Each Validator</h3>
-  <mat-card>
+  <mat-card class="mb-4">
     <mat-list *ngFor="let reward of totalRewards?.rewards">
       <mat-list-item>
         <span>Validator Address: </span>
@@ -35,7 +42,7 @@
         <span class="ml-2 break-all text-sm sm:text-base">{{ reward.validator_address }}</span>
       </mat-list-item>
       <mat-list-item *ngFor="let eachReward of reward?.reward">
-        <span>{{ eachReward.amount | number:'1.6-6' }}</span>
+        <span>{{ eachReward.amount | number: '1.6-6' }}</span>
         <span class="flex-auto"></span>
         <span>{{ eachReward.denom }}</span>
       </mat-list-item>

--- a/projects/main/src/app/views/accounts/account/staking/staking.component.html
+++ b/projects/main/src/app/views/accounts/account/staking/staking.component.html
@@ -8,15 +8,15 @@
   <p>*This account has no total rewards</p>
 </ng-template>
 <ng-template #existTotalRewards>
-  <h3>Total Rewards</h3>
-  <mat-card class="mb-4">
-    <mat-list *ngFor="let eachTotalReward of totalRewards?.total">
+  <h3 class="ml-4 mb-0">Total Rewards</h3>
+  <mat-card class="mb-2">
+    <mat-list *ngFor="let eachTotalReward of totalRewards?.total; last as last">
       <mat-list-item>
-        <span>{{ eachTotalReward.amount | number: '1.6-6' }}</span>
         <span class="flex-auto"></span>
+        <span class="mr-2">{{ eachTotalReward.amount | number: '1.6-6' }}</span>
         <span>{{ eachTotalReward.denom }}</span>
+        <mat-divider *ngIf="!last"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>
@@ -33,20 +33,21 @@
   <p>*This account has not received any rewards from validators</p>
 </ng-template>
 <ng-template #existEachValidatorRewards>
-  <h3>Rewards by Each Validator</h3>
-  <mat-card class="mb-4">
-    <mat-list *ngFor="let reward of totalRewards?.rewards">
+  <h3 class="ml-4 mb-0">Rewards by Each Validator</h3>
+  <mat-card class="mb-2" *ngFor="let reward of totalRewards?.rewards">
+    <mat-list>
       <mat-list-item>
         <span>Validator Address: </span>
         <span class="flex-auto"></span>
         <span class="ml-2 break-all text-sm sm:text-base">{{ reward.validator_address }}</span>
+        <mat-divider></mat-divider>
       </mat-list-item>
-      <mat-list-item *ngFor="let eachReward of reward?.reward">
-        <span>{{ eachReward.amount | number: '1.6-6' }}</span>
+      <mat-list-item *ngFor="let eachReward of reward?.reward; last as last">
         <span class="flex-auto"></span>
+        <span class="mr-2">{{ eachReward.amount | number: '1.6-6' }}</span>
         <span>{{ eachReward.denom }}</span>
+        <mat-divider *ngIf="!last"></mat-divider>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>

--- a/projects/main/src/app/views/accounts/account/txs/txs.component.html
+++ b/projects/main/src/app/views/accounts/account/txs/txs.component.html
@@ -1,27 +1,27 @@
-<h2>Transactions</h2>
-<div>
-  <mat-card>
-    <ng-container *ngIf="txsWithPagination?.tx_responses === undefined || null ; then empty; else exist"></ng-container>
-    <ng-template #empty></ng-template>
-    <ng-template #exist>
-      <mat-list>
-        <mat-list-item>
-          <span class="break-all truncate pr-4">Block Height</span>
-          <span class="flex-auto"></span>
-          <span class="break-all truncate">Tx Hash</span>
-        </mat-list-item>
+<h2 class="mb-0">Transactions</h2>
+<mat-card class="mb-4">
+  <ng-container
+    *ngIf="txsWithPagination?.tx_responses === undefined || null; then empty; else exist"
+  ></ng-container>
+  <ng-template #empty></ng-template>
+  <ng-template #exist>
+    <mat-list>
+      <mat-list-item>
+        <span class="break-all truncate pr-4">Block Height</span>
+        <span class="flex-auto"></span>
+        <span class="break-all truncate">Tx Hash</span>
         <mat-divider></mat-divider>
-      </mat-list>
-      <mat-nav-list>
-        <ng-container *ngFor="let tx of txsWithPagination?.tx_responses">
-          <mat-list-item routerLink="/txs/{{ tx.txhash }}">
-            <span class="pr-4 font-mono">{{ tx.height }}</span>
-            <span class="flex-auto"></span>
-            <span class="break-all truncate font-mono">{{ tx.txhash }}</span>
-          </mat-list-item>
-          <mat-divider></mat-divider>
-        </ng-container>
-      </mat-nav-list>
-    </ng-template>
-  </mat-card>
-</div>
+      </mat-list-item>
+    </mat-list>
+    <mat-nav-list>
+      <ng-container *ngFor="let tx of txsWithPagination?.tx_responses; last as last">
+        <mat-list-item routerLink="/txs/{{ tx.txhash }}">
+          <span class="pr-4 font-mono">{{ tx.height }}</span>
+          <span class="flex-auto"></span>
+          <span class="break-all truncate font-mono">{{ tx.txhash }}</span>
+          <mat-divider *ngIf="!last"></mat-divider>
+        </mat-list-item>
+      </ng-container>
+    </mat-nav-list>
+  </ng-template>
+</mat-card>

--- a/projects/main/src/app/views/blocks/block/block.component.html
+++ b/projects/main/src/app/views/blocks/block/block.component.html
@@ -1,5 +1,5 @@
-<h2>Block</h2>
-<mat-card>
+<h2 class="mb-0">Block</h2>
+<mat-card class="mb-4">
   <mat-list>
     <mat-list-item>
       <span class="whitespace-nowrap">BlockHash:</span>
@@ -19,15 +19,15 @@
       <span class="whitespace-nowrap">Timestamp:</span>
       <span class="flex-auto"></span>
       <span class="ml-2 break-all text-sm sm:text-base">
-        {{ block?.block?.header?.time | date : 'yyyy-M-d a h:mm:ss z' }}
+        {{ block?.block?.header?.time | date: 'yyyy-M-d a h:mm:ss z' }}
       </span>
     </mat-list-item>
   </mat-list>
 </mat-card>
 
-<h3>Validator sets</h3>
+<h2 class="mb-0">Validator Sets</h2>
 <ng-container *ngFor="let validatorset of validatorsets?.validators">
-  <mat-card class="mb-2">
+  <mat-card class="mb-4">
     <mat-list>
       <mat-list-item>
         <span class="whitespace-nowrap">Address:</span>
@@ -44,7 +44,9 @@
       <mat-list-item>
         <span class="whitespace-nowrap">Proposer Priority:</span>
         <span class="flex-auto"></span>
-        <span class="ml-2 break-all text-sm sm:text-base">{{ validatorset.proposer_priority }}</span>
+        <span class="ml-2 break-all text-sm sm:text-base">{{
+          validatorset.proposer_priority
+        }}</span>
       </mat-list-item>
     </mat-list>
   </mat-card>

--- a/projects/main/src/app/views/blocks/blocks.component.html
+++ b/projects/main/src/app/views/blocks/blocks.component.html
@@ -1,4 +1,4 @@
-<h2>Blocks</h2>
+<h2 class="mb-0">Blocks</h2>
 <div>
   <mat-card>
     <ng-container *ngIf="blocks === undefined || null; then empty; else exist"></ng-container>
@@ -18,13 +18,18 @@
             <span class="pr-4">{{ block?.block?.header?.height }}</span>
             <span class="flex-auto"></span>
             <span class="break-all text-sm sm:text-base">
-              {{ block?.block?.header?.time | date : 'yyyy-M-d a h:mm:ss z' }}
+              {{ block?.block?.header?.time | date: 'yyyy-M-d a h:mm:ss z' }}
             </span>
           </mat-list-item>
           <mat-divider></mat-divider>
         </ng-container>
-        <mat-paginator [length]="pageLength" [pageSize]="pageSize" [pageIndex]="pageNumber ? pageNumber - 1 : 0"
-          [pageSizeOptions]="pageSizeOptions ? pageSizeOptions : []" (page)="onPaginationChange($event)">
+        <mat-paginator
+          [length]="pageLength"
+          [pageSize]="pageSize"
+          [pageIndex]="pageNumber ? pageNumber - 1 : 0"
+          [pageSizeOptions]="pageSizeOptions ? pageSizeOptions : []"
+          (page)="onPaginationChange($event)"
+        >
         </mat-paginator>
       </mat-nav-list>
     </ng-template>

--- a/projects/main/src/app/views/home/bank/bank.component.html
+++ b/projects/main/src/app/views/home/bank/bank.component.html
@@ -1,8 +1,8 @@
-<h2>Total Supply</h2>
+<h2 class="mb-0">Total Supply</h2>
 <mat-card>
   <mat-list *ngFor="let sup of totalSupply?.supply; last as last">
     <mat-list-item>
-      <span>{{ sup.amount | number:'1.0-0' }}</span>
+      <span>{{ sup.amount | number: '1.0-0' }}</span>
       <span class="flex-auto"></span>
       <span>{{ sup.denom }}</span>
       <mat-divider *ngIf="!last"></mat-divider>

--- a/projects/main/src/app/views/home/blocks/blocks.component.html
+++ b/projects/main/src/app/views/home/blocks/blocks.component.html
@@ -1,7 +1,7 @@
-<h2>Latest Blocks</h2>
+<h2 class="mb-0 mt-4">Latest Blocks</h2>
 <div class="overflow-scroll h-80">
   <mat-card>
-    <ng-container *ngIf="latestBlocks === undefined || null ; then empty; else exist"></ng-container>
+    <ng-container *ngIf="latestBlocks === undefined || null; then empty; else exist"></ng-container>
     <ng-template #empty></ng-template>
     <ng-template #exist>
       <mat-list>

--- a/projects/main/src/app/views/home/distribution/distribution.component.html
+++ b/projects/main/src/app/views/home/distribution/distribution.component.html
@@ -1,8 +1,8 @@
-<h2>Community Pool</h2>
+<h2 class="mb-0 mt-2">Community Pool</h2>
 <mat-card>
   <mat-list *ngFor="let pool of communityPool?.pool; last as last">
     <mat-list-item>
-      <span>{{ pool.amount | number:'1.6-6' }}</span>
+      <span>{{ pool.amount | number: '1.6-6' }}</span>
       <span class="flex-auto"></span>
       <span>{{ pool.denom }}</span>
       <mat-divider *ngIf="!last"></mat-divider>

--- a/projects/main/src/app/views/home/home.component.html
+++ b/projects/main/src/app/views/home/home.component.html
@@ -1,4 +1,4 @@
-<h2>Node Info</h2>
+<h2 class="mb-0 mt-4">Node Info</h2>
 <mat-card>
   <mat-card-content>
     <mat-list>
@@ -39,7 +39,7 @@
   </mat-card-content>
 </mat-card>
 
-<h2>Application version</h2>
+<h2 class="mb-0 mt-4">Application Version</h2>
 <mat-card>
   <mat-card-content>
     <mat-list>
@@ -79,7 +79,7 @@
   </mat-card-content>
 </mat-card>
 
-<h2>Syncing</h2>
+<h2 class="mb-0 mt-4">Syncing</h2>
 <mat-card>
   <mat-card-content>
     <mat-list>

--- a/projects/main/src/app/views/home/mint/mint.component.html
+++ b/projects/main/src/app/views/home/mint/mint.component.html
@@ -1,21 +1,21 @@
-<h2>Inflation</h2>
+<h2 class="mb-0 mt-2">Inflation</h2>
 <mat-card>
   <mat-list>
     <mat-list-item>
       <span>Current Annual Inflation Rate: </span>
       <span class="flex-auto"></span>
-      <span class="ml-2">{{ inflation?.inflation | number:'1.9-9' }}</span>
+      <span class="ml-2">{{ inflation?.inflation | number: '1.9-9' }}</span>
     </mat-list-item>
   </mat-list>
 </mat-card>
 
-<h2>Annual Provisions</h2>
+<h2 class="mb-0 mt-2">Annual Provisions</h2>
 <mat-card>
   <mat-list>
     <mat-list-item>
       <span>Current Annual Expected Provisions: </span>
       <span class="flex-auto"></span>
-      <span class="ml-2">{{ annualProvisions?.annual_provisions | number:'1.6-6' }}</span>
+      <span class="ml-2">{{ annualProvisions?.annual_provisions | number: '1.6-6' }}</span>
     </mat-list-item>
   </mat-list>
 </mat-card>

--- a/projects/main/src/app/views/home/txs/txs.component.html
+++ b/projects/main/src/app/views/home/txs/txs.component.html
@@ -1,9 +1,8 @@
 <div class="flex flex-row justify-between content-start items-start">
-  <h2>Latest Transactions</h2>
+  <h2 class="mb-0 mt-4">Latest Transactions</h2>
   <mat-form-field appearance="fill">
     <mat-select [(value)]="selectedTxType" (valueChange)="onSelectedTxTypeChanged($event)">
-      <mat-option *ngFor="let txType of txTypeOptions" [value]="txType">{{txType}}
-      </mat-option>
+      <mat-option *ngFor="let txType of txTypeOptions" [value]="txType">{{ txType }} </mat-option>
     </mat-select>
   </mat-form-field>
 </div>

--- a/projects/main/src/app/views/keys/key/key.component.html
+++ b/projects/main/src/app/views/keys/key/key.component.html
@@ -1,4 +1,4 @@
-<h2>
+<h2 class="mb-0">
   <div class="flex flex-row">
     <span>{{ key?.id }}</span>
     <span class="flex-auto"></span>
@@ -8,52 +8,56 @@
   </div>
 </h2>
 
-<mat-list>
-  <mat-card>
+<mat-card class="mb-2">
+  <mat-list>
     <mat-list-item>
       <span class="whitespace-nowrap">Public Key:</span>
       <span class="flex-auto"></span>
       <span class="ml-2 break-all text-xs md:text-base">{{ key?.public_key }}</span>
+      <mat-divider></mat-divider>
     </mat-list-item>
-    <mat-divider></mat-divider>
     <mat-list-item>
       <span class="whitespace-nowrap">AccAddress:</span>
       <span class="flex-auto"></span>
       <span class="ml-2 break-all text-xs sm:text-base">{{ accAddress?.toString() }}</span>
+      <mat-divider></mat-divider>
     </mat-list-item>
-    <mat-divider></mat-divider>
     <mat-list-item>
       <span class="whitespace-nowrap">ValAddress:</span>
       <span class="flex-auto"></span>
       <span class="ml-2 break-all text-xs sm:text-base">{{ valAddress?.toString() }}</span>
     </mat-list-item>
-  </mat-card>
-</mat-list>
+  </mat-list>
+</mat-card>
 
 <ng-container *ngIf="faucets; then existFaucets; else emptyFaucets"></ng-container>
 <ng-template #existFaucets>
-  <mat-nav-list>
-    <mat-card>
-      <ng-container *ngFor="let faucet of faucets">
-        <mat-list-item routerLink="/faucet" [queryParams]="{
+  <mat-card class="mb-2">
+    <mat-nav-list>
+      <ng-container *ngFor="let faucet of faucets; last as last">
+        <mat-list-item
+          routerLink="/faucet"
+          [queryParams]="{
             address: accAddress?.toString(),
             denom: faucet.denom,
             amount: faucet.creditAmount
-          }">
+          }"
+        >
           <mat-icon color="accent">clean_hands</mat-icon>
           Go to Faucet of {{ faucet.denom }}
+          <mat-divider *ngIf="!last"></mat-divider>
         </mat-list-item>
       </ng-container>
-    </mat-card>
-  </mat-nav-list>
+    </mat-nav-list>
+  </mat-card>
 </ng-template>
 <ng-template #emptyFaucets></ng-template>
 
-<mat-nav-list>
-  <mat-card>
+<mat-card class="mb-2">
+  <mat-nav-list>
     <mat-list-item routerLink="/accounts/{{ accAddress?.toString() }}">
       <mat-icon color="accent">account_balance_wallet </mat-icon>
       Show Account Info
     </mat-list-item>
-  </mat-card>
-</mat-nav-list>
+  </mat-nav-list>
+</mat-card>

--- a/projects/main/src/app/views/monitor/monitor.component.html
+++ b/projects/main/src/app/views/monitor/monitor.component.html
@@ -1,23 +1,37 @@
-<h2>Daily Rewards</h2>
-<mat-card>
+<h2 class="mb-0">Daily Rewards</h2>
+<mat-card class="mb-4">
   <form #formRef="ngForm" (submit)="onSubmit(startRef.value, endRef.value)">
     <mat-form-field class="w-full">
       <mat-label>Choose a Date Range</mat-label>
       <mat-date-range-input [rangePicker]="picker">
-        <input #startRef="ngModel" name="startDate" [ngModel]="startDate" matStartDate matInput placeholder="Start date"
-          required />
-        <input #endRef="ngModel" name="endDate" [ngModel]="endDate" matEndDate matInput placeholder="End date"
-          required />
+        <input
+          #startRef="ngModel"
+          name="startDate"
+          [ngModel]="startDate"
+          matStartDate
+          matInput
+          placeholder="Start date"
+          required
+        />
+        <input
+          #endRef="ngModel"
+          name="endDate"
+          [ngModel]="endDate"
+          matEndDate
+          matInput
+          placeholder="End date"
+          required
+        />
       </mat-date-range-input>
       <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-date-range-picker #picker></mat-date-range-picker>
     </mat-form-field>
     <br />
-    <button mat-flat-button class="w-full" color="accent" [disabled]="formRef.invalid">Submit</button>
+    <button mat-flat-button class="w-full" color="accent" [disabled]="formRef.invalid">
+      Submit
+    </button>
   </form>
 </mat-card>
-<br />
-<br />
 
 <ng-container *ngIf="dataArray === null; then loading; else loaded"></ng-container>
 <ng-template #loading>
@@ -29,7 +43,7 @@
 <ng-template #loaded>
   <ng-container *ngIf="(dataArray || []).length > 0; else empty">
     <ng-container *ngFor="let data of dataArray">
-      <mat-card>
+      <mat-card class="mb-4">
         <mat-list>
           <mat-list-item>
             <span>Date:</span>
@@ -40,25 +54,17 @@
           <mat-list-item>
             <span>Commission:</span>
             <span class="flex-auto"></span>
-            <span>{{
-              data.result.commission.commission.commission[0].amount
-              }}</span>
+            <span>{{ data.result.commission.commission.commission[0].amount }}</span>
             <span class="flex-auto"></span>
-            <span>{{
-              data.result.commission.commission.commission[0].denom
-              }}</span>
+            <span>{{ data.result.commission.commission.commission[0].denom }}</span>
           </mat-list-item>
           <mat-divider></mat-divider>
           <mat-list-item>
             <span>Outstanding Rewards:</span>
             <span class="flex-auto"></span>
-            <span>{{
-              data.result.outstanding_rewards.rewards.rewards[0].amount
-              }}</span>
+            <span>{{ data.result.outstanding_rewards.rewards.rewards[0].amount }}</span>
             <span class="flex-auto"></span>
-            <span>{{
-              data.result.outstanding_rewards.rewards.rewards[0].denom
-              }}</span>
+            <span>{{ data.result.outstanding_rewards.rewards.rewards[0].denom }}</span>
           </mat-list-item>
           <mat-divider></mat-divider>
           <mat-list-item>
@@ -69,7 +75,6 @@
           <mat-divider></mat-divider>
         </mat-list>
       </mat-card>
-      <br />
     </ng-container>
   </ng-container>
 </ng-template>

--- a/projects/main/src/app/views/txs/tx/tx.component.html
+++ b/projects/main/src/app/views/txs/tx/tx.component.html
@@ -1,5 +1,5 @@
-<h2>Transaction</h2>
-<mat-card>
+<h2 class="mb-0">Transaction</h2>
+<mat-card class="mb-4">
   <mat-list>
     <mat-list-item>
       <span class="whitespace-nowrap">TxHash:</span>
@@ -33,17 +33,16 @@
       <span class="whitespace-nowrap">Timestamp: </span>
       <span class="flex-auto"></span>
       <span class="ml-2 break-all text-xs sm:text-base">
-        {{ tx?.tx_response?.timestamp | date : 'yyyy-M-d a h:mm:ss z' }}
+        {{ tx?.tx_response?.timestamp | date: 'yyyy-M-d a h:mm:ss z' }}
       </span>
     </mat-list-item>
-
   </mat-list>
 </mat-card>
 
-<h3>Msgs</h3>
+<h2 class="mb-0">Msgs</h2>
 <ng-template ngFor let-message [ngForOf]="tx?.tx?.body?.messages">
   <ng-container *ngIf="unpackMsg(message) as msg">
-    <mat-card>
+    <mat-card class="mb-4">
       <mat-list>
         <mat-list-item>
           <span class="whitespace-nowrap">Type: </span>
@@ -64,10 +63,10 @@
   </ng-container>
 </ng-template>
 
-<h3>Signatures</h3>
+<h2 class="mb-0">Signatures</h2>
 <ng-template ngFor let-signerInfo [ngForOf]="tx?.tx?.auth_info?.signer_infos">
   <ng-container *ngIf="unpackKey(signerInfo.public_key) as pubKey">
-    <mat-card class="mb-2">
+    <mat-card class="mb-4">
       <mat-list>
         <mat-list-item>
           <span class="whitespace-nowrap">Key Type: </span>
@@ -91,10 +90,10 @@
   </ng-container>
 </ng-template>
 
-<h3>Logs</h3>
+<h2 class="mb-0">Logs</h2>
 <ng-template ngFor let-log [ngForOf]="tx?.tx_response?.logs">
   <ng-template ngFor let-event [ngForOf]="log.events">
-    <mat-card class="mb-2">
+    <mat-card class="mb-4">
       <mat-list>
         <mat-list-item>
           <span class="whitespace-nowrap">Type: </span>

--- a/projects/main/src/app/views/txs/txs.component.html
+++ b/projects/main/src/app/views/txs/txs.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-row justify-between content-start items-start">
-  <h2>Transactions</h2>
+  <h2 class="mb-0 mt-4">Transactions</h2>
   <mat-form-field appearance="fill">
     <mat-select [(value)]="selectedTxType" (valueChange)="onSelectedTxTypeChanged($event)">
       <mat-option *ngFor="let txType of txTypeOptions" [value]="txType">{{ txType }} </mat-option>
@@ -30,9 +30,13 @@
         </ng-container>
       </mat-nav-list>
     </ng-template>
-    <mat-paginator [length]="pageLength" [pageSize]="pageInfo ? pageInfo.pageSize : 5"
-      [pageIndex]=" pageInfo ? pageInfo.pageNumber - 1 : 0" [pageSizeOptions]="pageSizeOptions ? pageSizeOptions : []"
-      (page)="onPaginationChange($event)">
+    <mat-paginator
+      [length]="pageLength"
+      [pageSize]="pageInfo ? pageInfo.pageSize : 5"
+      [pageIndex]="pageInfo ? pageInfo.pageNumber - 1 : 0"
+      [pageSizeOptions]="pageSizeOptions ? pageSizeOptions : []"
+      (page)="onPaginationChange($event)"
+    >
     </mat-paginator>
   </mat-card>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,4 +15,5 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  important: true,
 };


### PR DESCRIPTION
[https://github.com/CauchyE/telescope/issues/220
](https://github.com/CauchyE/telescope/issues/220)
の修正です。

mat-cardとタイトルの上下の余白を調整しました。
・基本はカード間は1rem （カードの内容によっては調整）
・カードとタイトル間は０
・カードタイトルのサイズをh3からh2へ統一。

![20220304_fix](https://user-images.githubusercontent.com/75844498/156765827-1d208c98-6149-4f1f-8ec7-bdf132db21a9.png)

デバック途中の箇所あるので、
次回確認後、レビューをお願いさせていただきます。