### PR TITLE
[pr-shadow] #272: fix: fix object display in tx page

### DIFF
--- a/projects/main/src/app/views/txs/tx/tx.component.html
+++ b/projects/main/src/app/views/txs/tx/tx.component.html
@@ -33,10 +33,9 @@
       <span class="whitespace-nowrap">Timestamp: </span>
       <span class="flex-auto"></span>
       <span class="ml-2 break-all text-xs sm:text-base">
-        {{ tx?.tx_response?.timestamp | date : 'yyyy-M-d a h:mm:ss z' }}
+        {{ tx?.tx_response?.timestamp | date: 'yyyy-M-d a h:mm:ss z' }}
       </span>
     </mat-list-item>
-
   </mat-list>
 </mat-card>
 
@@ -78,13 +77,13 @@
         <mat-list-item>
           <span class="whitespace-nowrap">Public Key: </span>
           <span class="flex-auto"></span>
-          <span class="ml-2 break-all">{{ pubKey?.toString() }}</span>
+          <span class="ml-2 break-all">{{ getPublicKey(pubKey) }}</span>
         </mat-list-item>
         <mat-divider [inset]="true"></mat-divider>
         <mat-list-item>
           <span class="whitespace-nowrap">Signature: </span>
           <span class="flex-auto"></span>
-          <span class="ml-2 break-all">{{ signerInfo?.mode_info }}</span>
+          <span class="ml-2 break-all">{{ signerInfo?.mode_info?.single?.mode }}</span>
         </mat-list-item>
       </mat-list>
     </mat-card>

--- a/projects/main/src/app/views/txs/tx/tx.component.ts
+++ b/projects/main/src/app/views/txs/tx/tx.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { cosmosclient } from '@cosmos-client/core';
+import { cosmosclient, proto } from '@cosmos-client/core';
 import { CosmosTxV1beta1GetTxResponse } from '@cosmos-client/core/esm/openapi';
 
 @Component({
@@ -37,5 +37,12 @@ export class TxComponent implements OnInit {
 
   entries(value: unknown) {
     return Object.entries(value as any);
+  }
+
+  getPublicKey(pubkey: any): string {
+    const publicKey = new proto.cosmos.crypto.secp256k1.PubKey({
+      key: pubkey.key,
+    });
+    return cosmosclient.AccAddress.fromPublicKey(publicKey).toString();
   }
 }


### PR DESCRIPTION
<!-- PR_SHADOW_ORIGINAL: cauchye/telescope#272 -->
<!-- PR_SHADOW_MANAGED -->

This pull request is an automated [pr-shadow](https://github.com/Senna46/pr-shadow) mirror of #272.

Cursor Bugbot (Individual) only reviews PRs authored by @Senna46. This mirror exists so Bugbot and Fixooly can run.

**Do not merge this PR into the default branch.** pr-shadow will retarget it or close it automatically.

Original author: @taro04
Original: https://github.com/cauchye/telescope/pull/272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes on the tx detail view with no auth, API, or persistence impact.
> 
> **Overview**
> Fixes **transaction detail** fields that were rendering as opaque objects instead of readable values.
> 
> **Public key** now uses a new `getPublicKey()` helper that encodes `pubkey.key` as a **hex string** (or empty when missing), replacing `toString()` on the unpacked key object.
> 
> **Signature** row now binds **`signerInfo.mode_info.single.mode`** so the UI shows the sign mode enum/value instead of the whole `mode_info` object.
> 
> Includes minor template cleanup: Angular `date` pipe spacing and removal of an extra blank line after the timestamp row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e431ea7612e464bf2574b24b07262a2ee8c42ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->