### PR TITLE
[pr-shadow] #210: [WIP] feat: add slashing pagination

### DIFF
--- a/projects/main/src/app/pages/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/pages/accounts/account/distribution/distribution.component.html
@@ -1,1 +1,3 @@
-<view-distribution [commission]="commission$ | async" [rewards]="rewards$ | async" [slashes]="slashes$ | async"></view-distribution>
+<view-distribution [commission]="commission$ | async" [rewards]="rewards$ | async" [slashes]="slashes$ | async"
+  [displaySize]="displaySize$ | async" [displayNumber]="displayNumber$ | async" [displayLength]="displayLength$ | async"
+  [displaySizeOptions]="displaySizeOptions" (paginationChange)="appPaginationChanged($event)"></view-distribution>

--- a/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
@@ -2,14 +2,16 @@ import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { cosmosclient, rest } from '@cosmos-client/core';
+import { PageEvent } from '@angular/material/paginator';
 import {
   CosmosDistributionV1beta1QueryValidatorSlashesResponse,
   InlineResponse20047,
   QueryValidatorCommissionResponseIsTheResponseTypeForTheQueryValidatorCommissionRPCMethod,
 } from '@cosmos-client/core/esm/openapi/api';
 import { CosmosSDKService } from 'projects/main/src/app/models/cosmos-sdk.service';
-import { combineLatest, Observable, of } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
+import { map, switchMap, mergeMap } from 'rxjs/operators';
+import { InlineResponse20035 } from '@cosmos-client/core/esm/openapi';
 
 @Component({
   selector: 'app-distribution',
@@ -17,12 +19,22 @@ import { map, mergeMap } from 'rxjs/operators';
   styleUrls: ['./distribution.component.css'],
 })
 export class DistributionComponent implements OnInit {
+
+  displaySizeOptions = [5, 10, 20, 50, 100];
+  displaySize$: BehaviorSubject<number> = new BehaviorSubject(10);
+  displayNumber$: BehaviorSubject<number> = new BehaviorSubject(1);
+  displayLength$: BehaviorSubject<number> = new BehaviorSubject(0);
+
   commission$: Observable<
     | QueryValidatorCommissionResponseIsTheResponseTypeForTheQueryValidatorCommissionRPCMethod
     | undefined
   >;
   rewards$: Observable<InlineResponse20047 | undefined>;
   slashes$: Observable<CosmosDistributionV1beta1QueryValidatorSlashesResponse | undefined>;
+
+  latestBlock$: Observable<InlineResponse20035 | undefined>;
+  slashingDisplayOffset$: Observable<bigint>;
+  slashesTotalCount$: Observable<bigint>;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -72,17 +84,70 @@ export class DistributionComponent implements OnInit {
       }),
     );
 
-    this.slashes$ = combined$.pipe(
-      mergeMap(([sdk, accAddress, valAddress]) => {
+    this.latestBlock$ = this.cosmosSDK.sdk$.pipe(
+      mergeMap((sdk) =>
+        rest.tendermint.getLatestBlock(sdk.rest).then((res) => res.data)),
+    );
+
+    this.slashesTotalCount$ = combineLatest([this.cosmosSDK.sdk$, accAddress$, valAddress$, this.latestBlock$]).pipe(
+      switchMap(([sdk, address, valAddress, latestBlock]) => {
+        return rest.distribution
+          .validatorSlashes(
+            sdk.rest,
+            valAddress!,
+            "10",
+            "20",
+            undefined,
+            BigInt(10),
+            BigInt(100),
+            true
+          )
+          .then((res) => {
+            console.log("ac-dbg", res)//debug
+            return res.data.slashes?.length ? BigInt(res.data.slashes?.length) : BigInt(0)
+          }
+          )
+      }),
+    );
+
+    this.slashesTotalCount$.subscribe((slashesTotalCount) => {
+      this.displayLength$.next(parseInt(slashesTotalCount.toString()));
+    });
+
+    this.slashingDisplayOffset$ = combineLatest([this.displayNumber$, this.displaySize$, this.displayLength$]).pipe(
+      map(([displayNumber, displaySize, latestBlock]) => {
+        const displayOffset = BigInt(latestBlock) - BigInt(displaySize) * BigInt(displayNumber);
+        return displayOffset;
+      }),
+    );
+
+    this.slashes$ = combineLatest([this.cosmosSDK.sdk$, accAddress$, valAddress$, this.displaySize$, this.displayNumber$, this.displayLength$]).pipe(
+      switchMap(([sdk, accAddress, valAddress, displaySize, displayOffset, latestBlock]) => {
         if (accAddress === undefined || valAddress === undefined) {
           return of(undefined);
         }
+        const modifiedDisplayOffset = displayOffset < 1 ? BigInt(1) : BigInt(displayOffset);
+        const modifiedDisplaySize = displayOffset < 1 ? BigInt(displayOffset) + BigInt(displaySize) : BigInt(displaySize);
         return rest.distribution
-          .validatorSlashes(sdk.rest, valAddress, '1', '2') // Todo: '2' must be fixed to latest block height and add pagination support!
+          .validatorSlashes(
+            sdk.rest,
+            valAddress,
+            '1',
+            String(latestBlock),
+            undefined,
+            modifiedDisplayOffset,
+            modifiedDisplaySize,
+            true
+          )
           .then((res) => res.data);
       }),
     );
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
+
+  appPaginationChanged(pageEvent: PageEvent): void {
+    this.displaySize$.next(pageEvent.pageSize);
+    this.displayNumber$.next(pageEvent.pageIndex + 1);
+  }
 }

--- a/projects/main/src/app/pages/txs/txs.component.ts
+++ b/projects/main/src/app/pages/txs/txs.component.ts
@@ -52,8 +52,10 @@ export class TxsComponent implements OnInit {
             undefined,
             true,
           )
-          .then((res) =>
-            res.data.pagination?.total ? BigInt(res.data.pagination?.total) : BigInt(0),
+          .then((res) => {
+            console.log("tx-dbg", res)//debug
+            return res.data.pagination?.total ? BigInt(res.data.pagination?.total) : BigInt(0)
+          }
           )
           .catch((error) => {
             console.error(error);
@@ -93,8 +95,8 @@ export class TxsComponent implements OnInit {
         // Note: This is strange. This is temporary workaround way.
         const temporaryWorkaroundPageSize =
           txTotalCount === BigInt(1) &&
-          modifiedPageOffset === BigInt(1) &&
-          modifiedPageSize === BigInt(1)
+            modifiedPageOffset === BigInt(1) &&
+            modifiedPageSize === BigInt(1)
             ? modifiedPageSize + BigInt(1)
             : modifiedPageSize;
 
@@ -123,7 +125,7 @@ export class TxsComponent implements OnInit {
     );
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 
   appSelectedTxTypeChanged(selectedTxType: string): void {
     this.selectedTxType$.next(selectedTxType);

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -60,5 +60,8 @@
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
     </mat-list>
+    <mat-paginator [length]="displayLength" [pageSize]="displaySize" [pageIndex]="displayNumber ? displayNumber - 1 : 0"
+      [pageSizeOptions]="displaySizeOptions ? displaySizeOptions : []" (page)="onPaginationChange($event)">
+    </mat-paginator>
   </mat-card>
 </ng-template>

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { PageEvent } from '@angular/material/paginator';
 import {
   CosmosDistributionV1beta1QueryValidatorSlashesResponse,
   InlineResponse20047,
@@ -17,8 +18,24 @@ export class DistributionComponent implements OnInit {
   rewards?: InlineResponse20047 | null;
   @Input()
   slashes?: CosmosDistributionV1beta1QueryValidatorSlashesResponse | null;
+  @Input()
+  displaySizeOptions?: number[] | null;
+  @Input()
+  displaySize?: number | null;
+  @Input()
+  displayNumber?: number | null;
+  @Input()
+  displayLength?: number | null;
+  @Output()
+  paginationChange: EventEmitter<PageEvent>;
 
-  constructor() { }
+  constructor() {
+    this.paginationChange = new EventEmitter();
+  }
 
   ngOnInit(): void { }
+
+  onPaginationChange(pageEvent: PageEvent): void {
+    this.paginationChange.emit(pageEvent);
+  }
 }


### PR DESCRIPTION
<!-- PR_SHADOW_ORIGINAL: cauchye/telescope#210 -->
<!-- PR_SHADOW_MANAGED -->

This pull request is an automated [pr-shadow](https://github.com/Senna46/pr-shadow) mirror of #210.

Cursor Bugbot (Individual) only reviews PRs authored by @Senna46. This mirror exists so Bugbot and Fixooly can run.

**Do not merge this PR into the default branch.** pr-shadow will retarget it or close it automatically.

Original author: @taro04
Original: https://github.com/cauchye/telescope/pull/210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pagination math and REST query parameters affect which slash events load; mistakes could show wrong or empty data, but scope is limited to the distribution UI and read-only chain queries.
> 
> **Overview**
> Adds **client-side pagination** for validator slashes on the account distribution view, replacing the previous hardcoded `validatorSlashes` range (`'1'`–`'2'`) with requests scoped to the **latest block height** and API offset/limit.
> 
> The page container now tracks page size, index, and total slash count (via `count_total`), derives a reverse offset the same way as the txs list, and refetches slashes when pagination changes. The `view-distribution` template gains a **Material paginator** wired through new inputs and a `paginationChange` output.
> 
> `txs.component.ts` only has minor formatting tweaks (indentation / `ngOnInit` spacing), with no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c0ffa9130c89508f2ee7674ef253ac94ed9766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->